### PR TITLE
docs: expand introduction and add results summary

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 
 # HR Chat Classification – Bewerbungs‑Repo (Single Dataset)
 
-Dieses Repo zeigt eine reproduzierbare Textklassifikation (5 HR‑Kategorien) auf **einem** synthetischen,
-realistisch verrauschten Korpus (**core**). Ziel ist die **nachvollziehbare Gegenüberstellung** einer
-klassischen Bag‑of‑Words‑Baseline (**Naive Bayes**) mit einem robusteren Ansatz (**BERT‑Proxy via LinearSVC**).
+## Einleitung
+Ziel des Projekts ist die automatische Klassifikation von HR‑Chat‑Nachrichten in fünf inhaltliche Kategorien, um Supportprozesse zu strukturieren. Die Motivation liegt darin, eine leicht nachvollziehbare Pipeline bereitzustellen und den Nutzen moderner Sprachmodelle gegenüber klassischen Bag‑of‑Words‑Verfahren zu demonstrieren. Dafür werden eine einfache **Naive‑Bayes**‑Baseline und ein **BERT‑Proxy** (BERT‑Embeddings + LinearSVC) auf einem synthetischen, realistisch verrauschten Korpus (**core**) verglichen. Alle Daten sind vollständig synthetisch und damit DSGVO‑konform.
 
 ## Quickstart
 ```bash
@@ -12,6 +11,15 @@ python src/make_all_results.py
 ```
 Erzeugt: `results/confusion_nb.png`, `results/confusion_svc.png`, `results/per_class_f1_*.png`,
 `results/overlay_*.png` sowie `results/metrics_core.json`.
+
+## Ergebnisse
+
+| Modell | Accuracy | F1 (macro) |
+| --- | --- | --- |
+| Naive Bayes | 0.622 | 0.613 |
+| BERT‑Proxy (LinearSVC) | 0.623 | 0.615 |
+
+Weitere Details und Visualisierungen finden sich in [docs/Results.md](docs/Results.md). Die zugrunde liegenden Daten sind vollständig synthetisch und DSGVO‑konform.
 
 ## Kernaussagen
 - **Konfusionsmatrizen mit sichtbarer Unschärfe** (keine perfekte Diagonale), passend zu realen HR‑Chats.


### PR DESCRIPTION
## Summary
- add detailed introduction outlining project goals, motivation and comparison of Naive Bayes baseline with BERT proxy
- summarize accuracy and macro-F1 results in a new table and link to docs/Results.md
- clarify that all data is synthetic and GDPR compliant

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68be892b554c8331905fb874fb7f4ccc