### PR TITLE
Add reproduction guide and link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ python src/make_all_results.py
 Erzeugt: `results/confusion_nb.png`, `results/confusion_svc.png`, `results/per_class_f1_*.png`,
 `results/overlay_*.png` sowie `results/metrics_core.json`.
 
+Eine ausführliche Schritt-für-Schritt-Anleitung zur Reproduktion findet sich in
+[docs/Reproduction.md](docs/Reproduction.md).
+
 ## Kernaussagen
 - **Konfusionsmatrizen mit sichtbarer Unschärfe** (keine perfekte Diagonale), passend zu realen HR‑Chats.
 - **Baseline vs. Proxy**: Der Proxy trennt robuster, NB zeigt stärkere Verwechslungen bei thematisch nahen Klassen.

--- a/docs/Reproduction.md
+++ b/docs/Reproduction.md
@@ -1,0 +1,24 @@
+# Reproduktion
+
+Diese Anleitung beschreibt, wie sich die Ergebnisse dieses Repos vollständig neu erzeugen lassen.
+
+## Voraussetzungen
+- Python 3.10 oder neuer (getestet mit 3.12)
+- Keine spezielle Hardware notwendig; CPU genügt.
+
+## Installation
+```bash
+pip install -r requirements.txt
+```
+
+## Daten generieren & Modelle ausführen
+Das Skript `src/make_all_results.py` erzeugt den synthetischen Korpus, trainiert Naive Bayes und LinearSVC und legt Kennzahlen sowie Plots ab.
+```bash
+python src/make_all_results.py
+```
+
+## Artefakte
+- `results/`: CSVs, Metriken und Konfusionsmatrizen.
+- `docs/figures/`: Kopien der relevanten Grafiken für die Dokumentation.
+
+Die Seeds sind fest gesetzt; erneute Durchläufe liefern identische Resultate.


### PR DESCRIPTION
## Summary
- Document step-by-step reproduction process in new `docs/Reproduction.md`
- Link README to the detailed reproduction guide

## Testing
- `python src/make_all_results.py`

------
https://chatgpt.com/codex/tasks/task_e_68be892d4d048331bc650233bf9ddc09